### PR TITLE
fix: apply dark mode consistently across all pages

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -12,9 +12,9 @@ function ChatContent() {
     const hospitalName = searchParams.get("name");
 
     return (
-        <Section className="min-h-[calc(100vh-4rem)] flex items-center bg-slate-50/50">
+        <Section className="min-h-[calc(100vh-4rem)] flex items-center bg-muted/30">
             <Container>
-                <div className="max-w-2xl mx-auto text-center space-y-8 p-12 bg-white rounded-3xl shadow-xl border border-slate-100">
+                <div className="max-w-2xl mx-auto text-center space-y-8 p-12 bg-card rounded-3xl shadow-xl border border-border">
                     <div className="relative mx-auto w-24 h-24">
                         <div className="absolute inset-0 bg-primary/10 rounded-full animate-ping" />
                         <div className="relative w-24 h-24 bg-primary/20 rounded-full flex items-center justify-center">
@@ -23,7 +23,7 @@ function ChatContent() {
                     </div>
 
                     <div className="space-y-4">
-                        <div className="inline-flex items-center px-4 py-1.5 rounded-full bg-slate-100 text-slate-700 text-sm font-medium gap-2">
+                        <div className="inline-flex items-center px-4 py-1.5 rounded-full bg-muted text-muted-foreground text-sm font-medium gap-2">
                             <Hospital className="w-4 h-4" />
                             {hospitalName ? `Chat with ${hospitalName}` : "Hospital Chat"}
                         </div>

--- a/app/hospitals/page.tsx
+++ b/app/hospitals/page.tsx
@@ -30,14 +30,14 @@ interface HospitalData {
 
 function HospitalSkelton() {
   return (
-    <div className="p-6 rounded-xl border bg-white shadow-sm animate-pulse">
+    <div className="p-6 rounded-xl border bg-card shadow-sm animate-pulse">
       <div className="flex justify-between items-start">
         <div className="space-y-3 flex-1">
-          <div className="h-6 bg-slate-200 rounded w-3/4" />
-          <div className="h-4 bg-slate-100 rounded w-1/2" />
-          <div className="h-4 bg-slate-100 rounded w-1/3" />
+          <div className="h-6 bg-muted rounded w-3/4" />
+          <div className="h-4 bg-muted/70 rounded w-1/2" />
+          <div className="h-4 bg-muted/70 rounded w-1/3" />
         </div>
-        <div className="h-10 w-24 bg-slate-200 rounded" />
+        <div className="h-10 w-24 bg-muted rounded" />
       </div>
     </div>
   );
@@ -117,30 +117,30 @@ function HospitalContent() {
   // --- STATE 1: SEARCH VIEW (Hero Section) ---
   if (!pincode) {
     return (
-      <Section className="bg-slate-50/50 min-h-[calc(100vh-4rem)] flex items-center">
+      <Section className="bg-muted/30 min-h-[calc(100vh-4rem)] flex items-center">
         <Container>
           <div className="w-full max-w-lg mx-auto space-y-8 text-center">
-            <div className="mx-auto w-20 h-20 bg-rose-100 rounded-full flex items-center justify-center shadow-inner">
+            <div className="mx-auto w-20 h-20 bg-rose-100 dark:bg-rose-900/30 rounded-full flex items-center justify-center shadow-inner">
               <MapPin className="w-10 h-10 text-rose-600 animate-bounce" />
             </div>
 
             <div className="space-y-2">
-              <H1 className="text-slate-900">
+              <H1>
                 Find Nearby Hospitals
               </H1>
-              <P className="text-slate-500 text-lg">
+              <P className="text-muted-foreground text-lg">
                 Enter your pincode to instantly connect with medical facilities near you.
               </P>
             </div>
 
-            <div className="bg-white p-3 rounded-2xl shadow-lg border border-slate-100">
+            <div className="bg-card p-3 rounded-2xl shadow-lg border border-border">
               <form onSubmit={handleSearch} className="flex items-center gap-2">
                 <div className="relative flex-1">
-                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                   <input
                     type="text"
                     placeholder="Enter 6-digit Pincode"
-                    className="w-full pl-10 pr-4 py-4 rounded-xl text-lg outline-none placeholder:text-slate-300"
+                    className="w-full pl-10 pr-4 py-4 rounded-xl text-lg outline-none bg-transparent placeholder:text-muted-foreground text-foreground"
                     value={inputPincode}
                     onChange={(e) => setInputcode(e.target.value)}
                     maxLength={6}
@@ -162,7 +162,7 @@ function HospitalContent() {
   if (loading) {
     return (
       <div className="container max-w-5xl mx-auto pt-28 px-4 space-y-6">
-        <div className="h-8 bg-slate-200 rounded w-64 animate-pulse mb-8" />
+        <div className="h-8 bg-muted rounded w-64 animate-pulse mb-8" />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <HospitalSkelton />
           <HospitalSkelton />
@@ -175,7 +175,7 @@ function HospitalContent() {
 
   // --- STATE 3: RESULTS LIST ---
   return (
-    <Section className="bg-slate-50/50 min-h-screen">
+    <Section className="bg-muted/30 min-h-screen">
       <Container>
         {/* Header Section */}
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-12 gap-4">
@@ -198,35 +198,35 @@ function HospitalContent() {
         </div>
 
         {hospital.length === 0 ? (
-          <div className="text-center py-20 bg-white rounded-3xl border border-dashed border-slate-200">
-            <AlertCircle className="w-12 h-12 text-slate-300 mx-auto mb-4" />
-            <H3 className="text-slate-900">No hospitals found</H3>
-            <P className="text-slate-500">Try increasing your search radius or checking the pincode.</P>
+          <div className="text-center py-20 bg-card rounded-3xl border border-dashed border-border">
+            <AlertCircle className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
+            <H3>No hospitals found</H3>
+            <P className="text-muted-foreground">Try increasing your search radius or checking the pincode.</P>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 text-slate-900">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             {hospital.map((hospital) => (
               <div
                 key={hospital.id}
-                className="group bg-white rounded-3xl p-8 border border-slate-100 shadow-sm hover:shadow-xl hover:border-rose-100 transition-all duration-300 flex flex-col"
+                className="group bg-card rounded-3xl p-8 border border-border shadow-sm hover:shadow-xl hover:border-rose-100 dark:hover:border-rose-900 transition-all duration-300 flex flex-col"
               >
-                <div className="flex justify-between items-start mb-6 ">
+                <div className="flex justify-between items-start mb-6">
                   <div>
-                    <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-rose-50 text-rose-700 mb-3">
+                    <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400 mb-3">
                       {hospital.distance} km away
                     </span>
                     <H3 className="group-hover:text-rose-600 transition-colors">
                       {hospital.name}
                     </H3>
                   </div>
-                  <div className="p-3 bg-slate-50 rounded-2xl group-hover:bg-rose-50 transition-colors">
-                    <HospitalIcon className="w-6 h-6 text-slate-400 group-hover:text-rose-500" />
+                  <div className="p-3 bg-muted rounded-2xl group-hover:bg-rose-50 dark:group-hover:bg-rose-900/30 transition-colors">
+                    <HospitalIcon className="w-6 h-6 text-muted-foreground group-hover:text-rose-500" />
                   </div>
                 </div>
 
                 <div className="flex-1 space-y-4 mb-8">
-                  <div className="flex items-start gap-3 text-slate-600">
-                    <MapPin className="w-5 h-5 text-slate-400 shrink-0 mt-0.5" />
+                  <div className="flex items-start gap-3 text-muted-foreground">
+                    <MapPin className="w-5 h-5 shrink-0 mt-0.5" />
                     <span className="text-sm leading-relaxed">
                       {hospital.address !== "Address not available"
                         ? hospital.address
@@ -246,7 +246,7 @@ function HospitalContent() {
                 </div>
 
                 <Button
-                  className="w-full bg-slate-900 hover:bg-slate-800 text-white shadow-xl shadow-slate-900/10 gap-2 h-12 rounded-2xl text-base transition-all active:scale-[0.98]"
+                  className="w-full bg-foreground hover:bg-foreground/90 text-background shadow-xl gap-2 h-12 rounded-2xl text-base transition-all active:scale-[0.98]"
                   onClick={() => handleChatClick(hospital.id, hospital.name)}
                 >
                   <MessageSquare className="w-4 h-4" />
@@ -267,10 +267,10 @@ export default function HospitalsPage() {
   return (
     <Suspense fallback={
       <div className="container max-w-5xl mx-auto pt-28 px-4 space-y-6">
-        <div className="h-8 bg-slate-200 rounded w-64 animate-pulse mb-8" />
+        <div className="h-8 bg-muted rounded w-64 animate-pulse mb-8" />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="p-6 rounded-xl border bg-white h-40 animate-pulse" />
-          <div className="p-6 rounded-xl border bg-white h-40 animate-pulse" />
+          <div className="p-6 rounded-xl border bg-card h-40 animate-pulse" />
+          <div className="p-6 rounded-xl border bg-card h-40 animate-pulse" />
         </div>
       </div>
     }>

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -71,32 +71,32 @@ function normalizeRisk(value?: string | null) {
 	const RiskIcon = config.icon;
 
 	return (
-		<div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-red-50 via-rose-50 to-pink-50">
+		<div className="relative min-h-screen overflow-hidden bg-background">
 			{/* Animated background elements */}
 			<div className="absolute inset-0 overflow-hidden pointer-events-none">
-				<div className="absolute top-20 left-10 w-72 h-72 bg-red-300/20 rounded-full blur-3xl animate-pulse" />
-				<div className="absolute bottom-20 right-10 w-96 h-96 bg-rose-300/20 rounded-full blur-3xl animate-pulse delay-1000" />
+				<div className="absolute top-20 left-10 w-72 h-72 bg-red-300/10 rounded-full blur-3xl animate-pulse" />
+				<div className="absolute bottom-20 right-10 w-96 h-96 bg-rose-300/10 rounded-full blur-3xl animate-pulse delay-1000" />
 			</div>
 
 			<div className="relative z-10 mx-auto flex min-h-screen w-full max-w-3xl flex-col justify-center gap-8 px-6 py-16">
 				{/* Header */}
 				<div className="text-center space-y-3">
-					<div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/80 backdrop-blur-sm shadow-md mb-4">
+					<div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-card backdrop-blur-sm shadow-md mb-4 border border-border">
 						<Sparkles className="w-5 h-5 text-red-600" />
-						<span className="text-sm font-semibold text-slate-700">
+						<span className="text-sm font-semibold text-foreground">
 							Screening Complete
 						</span>
 					</div>
 					<h1 className="text-4xl font-bold bg-gradient-to-r from-red-600 via-rose-600 to-pink-600 bg-clip-text text-transparent">
 						Screening Results
 					</h1>
-					<p className="text-slate-600 max-w-xl mx-auto">
+					<p className="text-muted-foreground max-w-xl mx-auto">
 						Review the automated risk calculation and recommended next steps
 					</p>
 				</div>
 
 				{/* Main Results Card */}
-				<div className="rounded-3xl border border-slate-200 bg-white/80 backdrop-blur-sm p-8 shadow-xl space-y-6">
+				<div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm p-8 shadow-xl space-y-6">
 					{/* Score Display */}
 					<div className="text-center space-y-4">
 						<div className="flex justify-center">
@@ -106,14 +106,14 @@ function normalizeRisk(value?: string | null) {
 						</div>
 
 						<div>
-							<p className="text-sm font-medium text-slate-600 mb-2">
+							<p className="text-sm font-medium text-muted-foreground mb-2">
 								Total Score
 							</p>
 							<div className="relative inline-block">
 								<span className={`text-6xl font-bold bg-gradient-to-r ${config.gradient} bg-clip-text text-transparent`}>
 									{score}
 								</span>
-								<span className="text-2xl text-slate-400 ml-1">/100</span>
+								<span className="text-2xl text-muted-foreground ml-1">/100</span>
 							</div>
 						</div>
 
@@ -126,18 +126,18 @@ function normalizeRisk(value?: string | null) {
 					</div>
 
 					{/* Divider */}
-					<div className="border-t border-slate-200" />
+					<div className="border-t border-border" />
 
 					{/* Risk Assessment */}
 					{isHighRisk && (
-						<div className="rounded-2xl border border-red-300 bg-red-50 p-5 space-y-2">
+						<div className="rounded-2xl border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-5 space-y-2">
 							<div className="flex items-center gap-2">
 								<AlertCircle className="w-5 h-5 text-red-600" />
-								<span className="font-semibold text-red-800">
+								<span className="font-semibold text-red-800 dark:text-red-400">
 									Immediate Care Required
 								</span>
 							</div>
-							<p className="text-sm text-red-700">
+							<p className="text-sm text-red-700 dark:text-red-300">
 								High risk of anemia detected. Please consult a healthcare
 								professional or visit a hospital immediately for proper
 								diagnosis and treatment.
@@ -146,14 +146,14 @@ function normalizeRisk(value?: string | null) {
 					)}
 
 					{isMediumRisk && (
-						<div className="rounded-2xl border border-orange-300 bg-orange-50 p-5 space-y-2">
+						<div className="rounded-2xl border border-orange-300 dark:border-orange-800 bg-orange-50 dark:bg-orange-900/20 p-5 space-y-2">
 							<div className="flex items-center gap-2">
 								<AlertTriangle className="w-5 h-5 text-orange-600" />
-								<span className="font-semibold text-orange-800">
+								<span className="font-semibold text-orange-800 dark:text-orange-400">
 									Medical Consultation Recommended
 								</span>
 							</div>
-							<p className="text-sm text-orange-700">
+							<p className="text-sm text-orange-700 dark:text-orange-300">
 								Medium risk detected. Schedule an appointment with a healthcare
 								provider for further evaluation and possible lab tests.
 							</p>
@@ -161,14 +161,14 @@ function normalizeRisk(value?: string | null) {
 					)}
 
 					{isLowRisk && (
-						<div className="rounded-2xl border border-green-300 bg-green-50 p-5 space-y-2">
+						<div className="rounded-2xl border border-green-300 dark:border-green-800 bg-green-50 dark:bg-green-900/20 p-5 space-y-2">
 							<div className="flex items-center gap-2">
 								<CheckCircle2 className="w-5 h-5 text-green-600" />
-								<span className="font-semibold text-green-800">
-									Low Risk of <span className="font-bold">Anemia </span> Detected 
+								<span className="font-semibold text-green-800 dark:text-green-400">
+									Low Risk of <span className="font-bold">Anemia </span> Detected
 								</span>
 							</div>
-							<p className="text-sm text-green-700">
+							<p className="text-sm text-green-700 dark:text-green-300">
 								Current symptoms suggest low risk of anemia. Continue
 								maintaining a healthy diet rich in iron and follow routine
 								health check-ups.
@@ -177,14 +177,14 @@ function normalizeRisk(value?: string | null) {
 					)}
 
 					{/* Next Actions */}
-					<div className="rounded-2xl bg-slate-50 border border-slate-200 p-5 space-y-3">
+					<div className="rounded-2xl bg-muted border border-border p-5 space-y-3">
 						<div className="flex items-center gap-2">
 							<Stethoscope className="w-5 h-5 text-red-600" />
-							<span className="font-semibold text-slate-800">
+							<span className="font-semibold text-foreground">
 								Recommended Next Steps
 							</span>
 						</div>
-						<ul className="space-y-2 text-sm text-slate-700">
+						<ul className="space-y-2 text-sm text-muted-foreground">
 							<li className="flex items-start gap-2">
 								<ArrowRight className="w-4 h-4 mt-0.5 text-red-600 flex-shrink-0" />
 								<span>
@@ -232,7 +232,7 @@ function normalizeRisk(value?: string | null) {
 
 						<button
 							onClick={() => window.print()}
-							className="w-full inline-flex items-center justify-center gap-2 rounded-full border-2 border-red-600 bg-white px-6 py-3.5 text-red-600 font-semibold hover:bg-red-50 transition-all duration-300"
+							className="w-full inline-flex items-center justify-center gap-2 rounded-full border-2 border-red-600 bg-background px-6 py-3.5 text-red-600 font-semibold hover:bg-red-50 dark:hover:bg-red-900/20 transition-all duration-300"
 						>
 							<FileText className="w-5 h-5" />
 							Print Results
@@ -241,7 +241,7 @@ function normalizeRisk(value?: string | null) {
 				</div>
 
 				{/* Disclaimer */}
-				<p className="text-xs text-center text-slate-500 max-w-2xl mx-auto">
+				<p className="text-xs text-center text-muted-foreground max-w-2xl mx-auto">
 					This is an automated screening tool and not a medical diagnosis.
 					Results should be confirmed by a qualified healthcare professional
 					with appropriate laboratory tests.

--- a/app/screen/page.tsx
+++ b/app/screen/page.tsx
@@ -41,16 +41,16 @@ type QuestionCardProps = {
 
 function QuestionCard({ title, assamese, icon: Icon, children }: QuestionCardProps) {
   return (
-    <div className="group rounded-2xl border border-slate-200 bg-white p-6 space-y-4 shadow-sm hover:shadow-md transition-all">
+    <div className="group rounded-2xl border border-border bg-card p-6 space-y-4 shadow-sm hover:shadow-md transition-all">
       <div className="flex items-start gap-3">
         {Icon && (
-          <div className="flex-shrink-0 w-10 h-10 rounded-full bg-rose-100 flex items-center justify-center">
+          <div className="flex-shrink-0 w-10 h-10 rounded-full bg-rose-100 dark:bg-rose-900/30 flex items-center justify-center">
             <Icon className="w-5 h-5 text-rose-600" />
           </div>
         )}
         <div className="flex-1">
-          <h3 className="font-semibold text-slate-900 text-lg">{title}</h3>
-          {assamese && <p className="text-sm text-slate-500 mt-1">{assamese}</p>}
+          <h3 className="font-semibold text-foreground text-lg">{title}</h3>
+          {assamese && <p className="text-sm text-muted-foreground mt-1">{assamese}</p>}
         </div>
       </div>
       <div>{children}</div>
@@ -65,9 +65,9 @@ function YesNoToggle({ value, onChange }: { value: boolean; onChange: (val: bool
         type="button"
         onClick={() => onChange(true)}
         className={`flex-1 py-3 px-4 rounded-xl border-2 transition-all duration-200 font-semibold flex items-center justify-center gap-2 ${
-          value === true 
-          ? "border-red-600 bg-red-50 text-red-700 shadow-sm" 
-          : "border-slate-100 bg-white text-slate-500 hover:border-slate-200"
+          value === true
+          ? "border-red-600 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400 shadow-sm"
+          : "border-border bg-card text-muted-foreground hover:border-border/80"
         }`}
       >
         Yes
@@ -76,9 +76,9 @@ function YesNoToggle({ value, onChange }: { value: boolean; onChange: (val: bool
         type="button"
         onClick={() => onChange(false)}
         className={`flex-1 py-3 px-4 rounded-xl border-2 transition-all duration-200 font-semibold flex items-center justify-center gap-2 ${
-          value === false 
-          ? "border-slate-600 bg-slate-100 text-slate-800 shadow-sm" 
-          : "border-slate-100 bg-white text-slate-500 hover:border-slate-200"
+          value === false
+          ? "border-foreground/60 bg-muted text-foreground shadow-sm"
+          : "border-border bg-card text-muted-foreground hover:border-border/80"
         }`}
       >
         No
@@ -130,15 +130,15 @@ export default function ScreenPage(){
     router.push(`/result?score=${result.score}&risk=${result.risk}`);
   };
   return (
-    <main className="min-h-screen bg-slate-50 py-12 px-4">
+    <main className="min-h-screen bg-background py-12 px-4">
         <div className="max-w-2xl mx-auto space-y-8">
             <div className="text-center space-y-3">
-                <div className="inline-flex items-center gap-5 mt-10 px-4 py-2 rounded-full bg-white shadow-sm border border-slate-100">
+                <div className="inline-flex items-center gap-5 mt-10 px-4 py-2 rounded-full bg-card shadow-sm border border-border">
                     <Sparkles className="w-4 h-4 text-rose-500 " />
-                    <span className="text-xs font-bold uppercase tracking-wider  text-slate-600">Health Assessment</span>
+                    <span className="text-xs font-bold uppercase tracking-wider text-muted-foreground">Health Assessment</span>
                 </div>
-                     <h1 className="text-4xl font-black text-slate-900">Endemic Screening</h1>
-                     <p className="text-slate-500">Provide accurate details for a better risk analysis.</p>
+                     <h1 className="text-4xl font-black text-foreground">Endemic Screening</h1>
+                     <p className="text-muted-foreground">Provide accurate details for a better risk analysis.</p>
             </div>
           
             <QuestionCard title="Age Group" assamese="বয়স গোট" icon={User}>
@@ -148,7 +148,7 @@ export default function ScreenPage(){
                   key={age}
                   onClick={() => setForm({...form, ageGroup: age})}
                   className={`py-3 rounded-xl border-2 capitalize font-medium transition-all ${
-                    form.ageGroup === age ? "border-rose-500 bg-rose-50 text-rose-700" : "border-slate-100 bg-white text-slate-600"
+                    form.ageGroup === age ? "border-rose-500 bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400" : "border-border bg-card text-muted-foreground"
                   }`}
                 >
                   {age}
@@ -162,9 +162,9 @@ export default function ScreenPage(){
             <input 
               type="range" min="1" max="5" value={form.fatigue} 
               onChange={(e) => setForm({...form, fatigue: parseInt(e.target.value)})}
-              className="w-full h-2 bg-rose-100 rounded-lg appearance-none cursor-pointer accent-rose-600"
+              className="w-full h-2 bg-rose-100 dark:bg-rose-900/30 rounded-lg appearance-none cursor-pointer accent-rose-600"
             />
-            <div className="flex justify-between text-xs font-bold text-slate-400 mt-2">
+            <div className="flex justify-between text-xs font-bold text-muted-foreground mt-2">
               <span>FRESH</span>
               <span className="text-rose-600">LEVEL {form.fatigue}</span>
               <span>EXHAUSTED</span>
@@ -199,7 +199,7 @@ export default function ScreenPage(){
                   key={p}
                   onClick={() => setForm({...form, pallor: p})}
                   className={`flex-1 py-3 rounded-xl border-2 capitalize font-medium transition-all ${
-                    form.pallor === p ? "border-rose-500 bg-rose-50 text-rose-700" : "border-slate-100 bg-white text-slate-600"
+                    form.pallor === p ? "border-rose-500 bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400" : "border-border bg-card text-muted-foreground"
                   }`}
                 >
                   {p === 'none' ? 'Normal' : p}
@@ -216,7 +216,7 @@ export default function ScreenPage(){
                   key={d}
                   onClick={() => setForm({...form, diet: d})}
                   className={`py-3 rounded-xl border-2 capitalize font-medium transition-all ${
-                    form.diet === d ? "border-rose-500 bg-rose-50 text-rose-700" : "border-slate-100 bg-white text-slate-600"
+                    form.diet === d ? "border-rose-500 bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400" : "border-border bg-card text-muted-foreground"
                   }`}
                 >
                   {d}
@@ -236,7 +236,7 @@ export default function ScreenPage(){
           </QuestionCard>
         <button
           onClick={submitHandler}
-          className="w-full bg-slate-900 text-white py-5 rounded-2xl font-black text-xl hover:bg-rose-600 transition-all shadow-xl active:scale-95"
+          className="w-full bg-foreground text-background py-5 rounded-2xl font-black text-xl hover:bg-rose-600 hover:text-white transition-all shadow-xl active:scale-95"
         >
           GET RESULTS →
         </button>

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -75,7 +75,7 @@ export default function SignInPage() {
 
     return (
         <div className="flex items-center justify-center min-h-[calc(100vh-4rem)] bg-muted/40 px-4 py-8">
-            <Card className="w-full max-w-md shadow-xl border-none ring-1 ring-slate-200">
+            <Card className="w-full max-w-md shadow-xl border-none ring-1 ring-border">
                 <CardHeader className="space-y-1">
                     <CardTitle className="text-3xl font-bold text-center tracking-tight">Arogya Assam</CardTitle>
                     <CardDescription className="text-center text-base">

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -90,7 +90,7 @@ export default function SignUpPage() {
 
     return (
         <div className="flex items-center justify-center min-h-[calc(100vh-4rem)] bg-muted/40 px-4 py-8">
-            <Card className="w-full max-w-md shadow-xl border-none ring-1 ring-slate-200">
+            <Card className="w-full max-w-md shadow-xl border-none ring-1 ring-border">
                 <CardHeader className="space-y-1">
                     <CardTitle className="text-3xl font-bold text-center tracking-tight">Create an Account</CardTitle>
                     <CardDescription className="text-center text-base">


### PR DESCRIPTION
Fixes #33

## Problem
Dark mode was only working on the landing page. All other pages used hardcoded Tailwind color classes (bg-white, bg-slate-50, text-slate-900, border-slate-200 etc.) that completely ignored the active theme, causing them to stay in light mode even after the user toggled dark mode.

## Root Cause
Pages were using hardcoded static colors instead of Tailwinds semantic theme-aware CSS variable classes. The ThemeProvider in the root layout was already correctly configured with next-themes (attribute=class), so the .dark class was being applied to the html element — but the pages were not using classes that respond to it.

## Changes Made

### app/hospitals/page.tsx
- Skeleton loader: bg-white to bg-card, bg-slate-200/100 to bg-muted
- Search section: bg-slate-50/50 to bg-muted/30, bg-white to bg-card, border-slate-100 to border-border, input placeholder color fixed
- Results section: bg-white cards to bg-card, border-slate-100 to border-border, text-slate-900/600/400 to text-foreground/muted-foreground, hover colors updated with dark: variants

### app/screen/page.tsx
- QuestionCard: bg-white to bg-card, border-slate-200 to border-border, text-slate-900/500 to text-foreground/muted-foreground
- YesNoToggle buttons: hardcoded slate colors replaced with border-border, bg-card, text-muted-foreground
- All selection buttons (age, pallor, diet): same treatment
- Main wrapper: bg-slate-50 to bg-background
- Submit button: bg-slate-900 text-white to bg-foreground text-background

### app/result/page.tsx
- Page background: hardcoded gradient replaced with bg-background
- Main card: bg-white/80 to bg-card/80, border-slate-200 to border-border
- Text colors: text-slate-600/400 to text-muted-foreground
- Alert boxes: added dark: variants for borders and backgrounds
- Next steps section: bg-slate-50 to bg-muted
- Print button: bg-white to bg-background with dark:hover variant

### app/chat/page.tsx
- Page section: bg-slate-50/50 to bg-muted/30
- Card: bg-white to bg-card, border-slate-100 to border-border
- Badge: bg-slate-100 text-slate-700 to bg-muted text-muted-foreground

### app/signin/page.tsx and app/signup/page.tsx
- Card ring: ring-slate-200 to ring-border
<img width="1916" height="1027" alt="image" src="https://github.com/user-attachments/assets/94872725-bad8-4bdb-bd8e-526ff9bfcb78" />
<img width="1897" height="1027" alt="image" src="https://github.com/user-attachments/assets/59879213-5909-437b-bf34-839a20fea13b" />

## Testing
1. Toggle dark mode from the navbar
2. Navigate to /hospitals, /screen, /result, /chat, /signin, /signup
3. All pages should now correctly reflect the selected theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling across multiple pages (chat, hospital search, results, screening, and authentication) to use design-system color tokens instead of hardcoded colors.
  * Added dark-mode support with theme-aware variants throughout the application for improved visual consistency and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->